### PR TITLE
URI.escape is obsolete

### DIFF
--- a/lib/fastlyctl/clone_utils.rb
+++ b/lib/fastlyctl/clone_utils.rb
@@ -59,12 +59,12 @@ module FastlyCTL
 
       if main === true
         # the "main-ness" of the vcl does not get carried over during creation. must explicitly set main
-        FastlyCTL::Fetcher.api_request(:put, "/service/#{sid}/version/#{version}/vcl/#{URI.escape(obj["name"])}/main")
+        FastlyCTL::Fetcher.api_request(:put, "/service/#{sid}/version/#{version}/vcl/#{FastlyCTL::Utils.percent_encode(obj["name"])}/main")
       end
 
       if type == "director"
         backends.each do |b|
-          FastlyCTL::Fetcher.api_request(:post, "/service/#{sid}/version/#{version}/director/#{URI.escape(obj["name"])}/backend/#{b}", body: obj )
+          FastlyCTL::Fetcher.api_request(:post, "/service/#{sid}/version/#{version}/director/#{FastlyCTL::Utils.percent_encode(obj["name"])}/backend/#{b}", body: obj )
         end
       end
 

--- a/lib/fastlyctl/commands/acl.rb
+++ b/lib/fastlyctl/commands/acl.rb
@@ -20,7 +20,7 @@ module FastlyCTL
       version = FastlyCTL::Fetcher.get_writable_version(id) unless options[:version]
       version ||= options[:version]
 
-      encoded_name = URI.escape(name) if name
+      encoded_name = FastlyCTL::Utils.percent_encode(name) if name
 
       case action
       when "create"

--- a/lib/fastlyctl/commands/condition.rb
+++ b/lib/fastlyctl/commands/condition.rb
@@ -32,7 +32,7 @@ module FastlyCTL
         version = FastlyCTL::Fetcher.get_writable_version(id) unless options[:version]
         version ||= options[:version].to_i
 
-        encoded_name = URI.escape(name) if name
+        encoded_name = FastlyCTL::Utils.percent_encode(name) if name
 
         case action 
             when "list"

--- a/lib/fastlyctl/commands/copy.rb
+++ b/lib/fastlyctl/commands/copy.rb
@@ -19,7 +19,7 @@ module FastlyCTL
       path += "/#{obj_name}" unless obj_type == "settings"
       obj = FastlyCTL::Fetcher.api_request(:get, path)
 
-      encoded_name = URI.escape(obj_name)
+      encoded_name = FastlyCTL::Utils.percent_encode(obj_name)
 
       if (obj_type == "settings")
         puts "Copying settings from #{id} version #{source_version} to #{target_id} version #{target_version}..."

--- a/lib/fastlyctl/commands/dictionary.rb
+++ b/lib/fastlyctl/commands/dictionary.rb
@@ -20,7 +20,7 @@ module FastlyCTL
       version = FastlyCTL::Fetcher.get_writable_version(id) unless options[:version]
       version ||= options[:version]
 
-      encoded_name = URI.escape(name) if name
+      encoded_name = FastlyCTL::Utils.percent_encode(name) if name
 
       case action
       when "create"
@@ -49,14 +49,14 @@ module FastlyCTL
         abort "Must specify name for dictionary" unless name
         abort "Must specify key and value for dictionary item" unless (key && value)
         dict = FastlyCTL::Fetcher.api_request(:get, "/service/#{id}/version/#{version}/dictionary/#{encoded_name}")
-        FastlyCTL::Fetcher.api_request(:put, "/service/#{id}/dictionary/#{dict["id"]}/item/#{key}", params: { item_value: value })   
+        FastlyCTL::Fetcher.api_request(:put, "/service/#{id}/dictionary/#{dict["id"]}/item/#{FastlyCTL::Utils.percent_encode(key)}", params: { item_value: value })   
 
         say("Dictionary item #{key} set to #{value}.")   
       when "remove"
         abort "Must specify name for dictionary" unless name
         abort "Must specify key for dictionary item" unless key
         dict = FastlyCTL::Fetcher.api_request(:get, "/service/#{id}/version/#{version}/dictionary/#{encoded_name}")
-        FastlyCTL::Fetcher.api_request(:delete, "/service/#{id}/dictionary/#{dict["id"]}/item/#{key}")
+        FastlyCTL::Fetcher.api_request(:delete, "/service/#{id}/dictionary/#{dict["id"]}/item/#{FastlyCTL::Utils.percent_encode(key)}")
 
         say("Item #{key} removed from dictionary #{name}.")
       when "list_items"

--- a/lib/fastlyctl/commands/snippet.rb
+++ b/lib/fastlyctl/commands/snippet.rb
@@ -18,7 +18,7 @@ module FastlyCTL
       version = FastlyCTL::Fetcher.get_writable_version(id) unless options[:version]
       version ||= options[:version].to_i
 
-      encoded_name = URI.escape(name) if name
+      encoded_name = FastlyCTL::Utils.percent_encode(name) if name
 
       filename = options.key?(:filename) ? options[:filename] : "#{name}.snippet"
 

--- a/lib/fastlyctl/fetcher.rb
+++ b/lib/fastlyctl/fetcher.rb
@@ -161,7 +161,7 @@ module FastlyCTL
     end
 
     def self.upload_snippet(service,version,content,name)
-      return FastlyCTL::Fetcher.api_request(:put, "/service/#{service}/version/#{version}/snippet/#{name}", {:endpoint => :api, body: {
+      return FastlyCTL::Fetcher.api_request(:put, "/service/#{service}/version/#{version}/snippet/#{FastlyCTL::Utils.percent_encode(name)}", {:endpoint => :api, body: {
           content: content
         }
       })
@@ -178,7 +178,7 @@ module FastlyCTL
         end
       end
 
-      response = FastlyCTL::Fetcher.api_request(:put, "/service/#{service}/version/#{version}/vcl/#{name}", {:endpoint => :api, body: params, expected_responses: [200,404]})
+      response = FastlyCTL::Fetcher.api_request(:put, "/service/#{service}/version/#{version}/vcl/#{FastlyCTL::Utils.percent_encode(name)}", {:endpoint => :api, body: params, expected_responses: [200,404]})
 
       # The VCL got deleted so recreate it.
       if response["msg"] == "Record not found"

--- a/lib/fastlyctl/utils.rb
+++ b/lib/fastlyctl/utils.rb
@@ -68,5 +68,10 @@ module FastlyCTL
 
       return diff
     end
+
+    def self.percent_encode(string)
+      # CGI.escape replace whitespace to "+" which is "%20" in a percent-encoding manner
+      CGI.escape(string).gsub('+', '%20')
+    end
   end
 end


### PR DESCRIPTION
also fix the issue where some of the requests are not escaping URI properly: https://github.com/fastly/fastlyctl/issues/5