### PR TITLE
Add support for ENV Variable

### DIFF
--- a/lib/fastlyctl.rb
+++ b/lib/fastlyctl.rb
@@ -26,5 +26,5 @@ module FastlyCTL
 
   Cookies = File.exist?(FastlyCTL::COOKIE_JAR) ? JSON.parse(File.read(FastlyCTL::COOKIE_JAR)) : {}
   # Don't allow header splitting with the key
-  Token = File.exist?(FastlyCTL::TOKEN_FILE) ? File.read(FastlyCTL::TOKEN_FILE) : (ENV['FASTLY_TOKEN'] ? ENV['FASTLY_TOKEN'] : false)
+  Token = File.exist?(FastlyCTL::TOKEN_FILE) ? File.read(FastlyCTL::TOKEN_FILE) : (ENV['FASTLYCLI_TOKEN'] ? ENV['FASTLYCLI_TOKEN'] : false)
 end

--- a/lib/fastlyctl.rb
+++ b/lib/fastlyctl.rb
@@ -26,5 +26,5 @@ module FastlyCTL
 
   Cookies = File.exist?(FastlyCTL::COOKIE_JAR) ? JSON.parse(File.read(FastlyCTL::COOKIE_JAR)) : {}
   # Don't allow header splitting with the key
-  Token = File.exist?(FastlyCTL::TOKEN_FILE) ? File.read(FastlyCTL::TOKEN_FILE) : false
+  Token = File.exist?(FastlyCTL::TOKEN_FILE) ? File.read(FastlyCTL::TOKEN_FILE) : (ENV['FASTLY_TOKEN'] ? ENV['FASTLY_TOKEN'] : false)
 end

--- a/lib/fastlyctl/cli.rb
+++ b/lib/fastlyctl/cli.rb
@@ -25,7 +25,7 @@ module FastlyCTL
     class_option :debug, :desc => 'Enabled debug mode output'
 
     def initialize(a,b,c)
-      unless File.exist?(FastlyCTL::TOKEN_FILE)
+      unless File.exist?(FastlyCTL::TOKEN_FILE) || ENV['FASTLY_TOKEN']
         if yes?("Unable to locate API token. Would you like to login first?")
           self.login
         end

--- a/lib/fastlyctl/cli.rb
+++ b/lib/fastlyctl/cli.rb
@@ -25,7 +25,7 @@ module FastlyCTL
     class_option :debug, :desc => 'Enabled debug mode output'
 
     def initialize(a,b,c)
-      unless File.exist?(FastlyCTL::TOKEN_FILE) || ENV['FASTLY_TOKEN']
+      unless File.exist?(FastlyCTL::TOKEN_FILE) || ENV['FASTLYCLI_TOKEN']
         if yes?("Unable to locate API token. Would you like to login first?")
           self.login
         end

--- a/lib/fastlyctl/version.rb
+++ b/lib/fastlyctl/version.rb
@@ -1,3 +1,3 @@
 module FastlyCTL
-  VERSION = "1.0.16"
+  VERSION = "1.0.17"
 end


### PR DESCRIPTION
Using a file at the home directory is not efficient for mult-tenancy or CI/CD. Allow the use of an environment variable to enable better CI/CD.