### PR TITLE
Read-only Operations

### DIFF
--- a/lib/fastlyctl/commands/acl.rb
+++ b/lib/fastlyctl/commands/acl.rb
@@ -1,6 +1,8 @@
 module FastlyCTL
   class CLI < Thor
-    desc "acl ACTION ACL_NAME IP", "Manipulate ACLS.\n  Actions:\n    create: Create an ACL\n
+    desc "acl ACTION ACL_NAME IP", "Manipulate ACLS.\n  
+    Actions:\n    
+    create: Create an ACL\n
     delete: Delete an ACL\n
     list: Provide a list of ACLs on this service\n
     add: Add an IP/subnet to an ACL\n
@@ -16,8 +18,11 @@ module FastlyCTL
       id ||= options[:service]
 
       abort "Could not parse service id from directory. Specify service id with --service or use from within service directory." unless id
+      
+      readonly = ["list", "list_ips"]
 
-      version = FastlyCTL::Fetcher.get_writable_version(id) unless options[:version]
+      version = FastlyCTL::Fetcher.get_service_version(id, readonly.include?(action)) unless options[:version]
+      
       version ||= options[:version]
 
       encoded_name = FastlyCTL::Utils.percent_encode(name) if name

--- a/lib/fastlyctl/commands/dictionary.rb
+++ b/lib/fastlyctl/commands/dictionary.rb
@@ -17,7 +17,9 @@ module FastlyCTL
 
       abort "Could not parse service id from directory. Specify service id with --service or use from within service directory." unless id
 
-      version = FastlyCTL::Fetcher.get_writable_version(id) unless options[:version]
+      readonly = ["list", "list_items"]
+
+      version = FastlyCTL::Fetcher.get_service_version(id, readonly.include?(action)) unless options[:version]
       version ||= options[:version]
 
       encoded_name = FastlyCTL::Utils.percent_encode(name) if name

--- a/lib/fastlyctl/commands/domain.rb
+++ b/lib/fastlyctl/commands/domain.rb
@@ -9,7 +9,9 @@ module FastlyCTL
 
       abort "Could not parse service id from directory. Use --s <service> to specify, vcl download, then try again." unless id
 
-      version = FastlyCTL::Fetcher.get_writable_version(id) unless options[:version]
+      readonly = ["list", "check"]
+
+      version = FastlyCTL::Fetcher.get_service_version(id, readonly.include?(action)) unless options[:version]
       version ||= options[:version].to_i
 
       case action

--- a/lib/fastlyctl/commands/logging/bigquery.rb
+++ b/lib/fastlyctl/commands/logging/bigquery.rb
@@ -106,7 +106,7 @@ module BigQuery
 
     def self.list(options)
         id = options[:service]
-        version = FastlyCTL::Fetcher.get_writable_version(id) unless options[:version]
+        version = FastlyCTL::Fetcher.get_active_version(id) unless options[:version]
         version ||= options[:version]
 
         puts "Listing all BigQuery configurations for service #{id} version #{version}"
@@ -119,7 +119,7 @@ module BigQuery
         required_opts = ["name"]
         ensure_opts(required_opts,options)
         id  = options[:service]
-        version = FastlyCTL::Fetcher.get_writable_version(id) unless options[:version]
+        version = FastlyCTL::Fetcher.get_active_version(id) unless options[:version]
         version ||= options[:version]
 
         resp = FastlyCTL::Fetcher.api_request(:get, "/service/#{id}/version/#{version}/logging/bigquery/#{options[:name]}")

--- a/lib/fastlyctl/fetcher.rb
+++ b/lib/fastlyctl/fetcher.rb
@@ -147,6 +147,14 @@ module FastlyCTL
 
       return version
     end
+    
+    def self.get_service_version(id, readonly=false)
+      if readonly
+        return self.get_active_version(id)
+      end
+      
+      return self.get_writable_version(id)
+    end
 
     def self.get_vcl(id, version, generated=false)
       if generated


### PR DESCRIPTION
This PR refactors the service version selection process to support read-only operations. If I am using a read-only token and try to retrieve a list of ACLs, it will fail if there is no writable version of the service. Listing ACLs is a read-only operation and does not need a writable version.