### PR TITLE
Adding FASTLY_APP back to the module

### DIFF
--- a/lib/fastlyctl.rb
+++ b/lib/fastlyctl.rb
@@ -20,6 +20,7 @@ include ERB::Util
 module FastlyCTL
   TOKEN_FILE = ENV['HOME'] + "/.fastlyctl_token"
   FASTLY_API = "https://api.fastly.com"
+  FASTLY_APP = "https://manage.fastly.com"
   FASTLY_RT_API = "https://rt.fastly.com"
   TANGO_PATH = "/configure/services/"
 


### PR DESCRIPTION
FASTLY_APP is still used in utils.rb and it needs to be initialized before open_service is called.